### PR TITLE
Handle error during parsing and don't throw it

### DIFF
--- a/src/main/java/org/jboss/pnc/kafkastore/kafka/Consumer.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/kafka/Consumer.java
@@ -45,21 +45,24 @@ public class Consumer {
      * @throws Exception
      */
     @Incoming("duration")
-    public void consume(String jsonString) throws Exception {
+    public void consume(String jsonString) {
         System.out.print(".");
 
-        // log.info("Incoming: {}", jsonString);
-        Optional<BuildStageRecord> buildStageRecord = mapper.mapKafkaMsgToBuildStageRecord(jsonString);
+        try {
+            Optional<BuildStageRecord> buildStageRecord = mapper.mapKafkaMsgToBuildStageRecord(jsonString);
 
-        // TODO: handle error better
-        // do this because method running in an IO thread and we can only store a POJO in a worker thread
-        buildStageRecord.ifPresent(br -> {
-            log.info(br.toString());
-            CompletableFuture.runAsync(() -> store(br)).exceptionally(e -> {
-                e.printStackTrace();
-                return null;
+            // TODO: handle error better
+            // do this because method running in an IO thread and we can only store a POJO in a worker thread
+            buildStageRecord.ifPresent(br -> {
+                log.info(br.toString());
+                CompletableFuture.runAsync(() -> store(br)).exceptionally(e -> {
+                    e.printStackTrace();
+                    return null;
+                });
             });
-        });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Transactional

--- a/src/main/java/org/jboss/pnc/kafkastore/mapper/BuildStageRecordMapper.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/mapper/BuildStageRecordMapper.java
@@ -44,7 +44,10 @@ public class BuildStageRecordMapper {
 
             if (kafkaMessageDTO.getMdc() != null
                     && kafkaMessageDTO.getMdc().getProcessStageName() != null
+                    && kafkaMessageDTO.getMdc().getProcessContext() != null
+                    && kafkaMessageDTO.getMdc().getProcessStageStep() != null
                     && kafkaMessageDTO.getMdc().getProcessStageStep().equals("END")
+                    && kafkaMessageDTO.getTimestamp() != null
                     && kafkaMessageDTO.getOperationTook() != null) {
 
                 BuildStageRecord buildStageRecord = new BuildStageRecord();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,8 @@
 %prod.mp.messaging.incoming.duration.ssl.truststore.location=${TRUSTSTORE_LOCATION:}
 %prod.mp.messaging.incoming.duration.ssl.truststore.password=${TRUSTSTORE_PASSWORD:}
 %prod.mp.messaging.incoming.duration.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+# Consume only 50 records at a time to be more responsive (default is 500)
+%prod.mp.messaging.incoming.duration.max.poll.records=50
 
 quarkus.hibernate-orm.database.generation = update
 quarkus.datasource.driver = ${QUARKUS_DATASOURCE_DRIVER:org.postgresql.Driver}


### PR DESCRIPTION
Throwing it causes the consumer to stop working at all

Also reduce the number of records to consume to improve responsiveness