### PR TITLE
[NCL-5479] Handle corner-case with WAITING_FOR_DEPENDENCIES

### DIFF
--- a/src/main/java/org/jboss/pnc/kafkastore/common/SortedSetOrder.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/common/SortedSetOrder.java
@@ -75,6 +75,13 @@ public class SortedSetOrder {
 
             // just make sure that all the fields are unique
             sorted = new ArrayList<>(new LinkedHashSet<>(finalSolution));
+
+            // handle corner-case: waiting for dependencies should always be the first metric
+            int index = sorted.indexOf("WAITING_FOR_DEPENDENCIES");
+            if (index > 0) {
+                sorted.add(0, "WAITING_FOR_DEPENDENCIES");
+                sorted.remove(index);
+            }
         }
 
         return this;


### PR DESCRIPTION
This state should always be the first item, if present