### PR TITLE
[NCL-6705] Aggregate retry data from log-event-duration

### DIFF
--- a/src/main/java/org/jboss/pnc/kafkastore/dto/ingest/MDC.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/dto/ingest/MDC.java
@@ -31,6 +31,7 @@ public class MDC {
 
     String processContext;
     String requestContext;
+    String processContextVariant;
 
     @JsonProperty("process_stage_name")
     String processStageName;

--- a/src/main/java/org/jboss/pnc/kafkastore/facade/BuildMetricsFetcher.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/facade/BuildMetricsFetcher.java
@@ -48,7 +48,16 @@ public class BuildMetricsFetcher {
 
             for (BuildStageRecord buildStageRecord : buildStageRecordList) {
                 metric.add(buildStageRecord.getBuildStage());
-                cache.put(getKeyForCache(id, buildStageRecord.getBuildStage()), buildStageRecord.getDuration());
+
+                // if step is not in cache, put duration
+                cache.computeIfAbsent(
+                        getKeyForCache(id, buildStageRecord.getBuildStage()),
+                        key -> buildStageRecord.getDuration());
+
+                // if step is already in cache, add to the existing duration
+                cache.computeIfPresent(
+                        getKeyForCache(id, buildStageRecord.getBuildStage()),
+                        (key, value) -> value + buildStageRecord.getDuration());
             }
             sortedSet.addList(metric);
         }

--- a/src/main/java/org/jboss/pnc/kafkastore/mapper/BuildStageRecordMapper.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/mapper/BuildStageRecordMapper.java
@@ -72,6 +72,10 @@ public class BuildStageRecordMapper {
 
                 buildStageRecord.setBuildStage(kafkaMessageDTO.getMdc().getProcessStageName());
                 buildStageRecord.setBuildId(buildId(kafkaMessageDTO.getMdc().getProcessContext()));
+
+                if (kafkaMessageDTO.getMdc().getProcessContextVariant() != null) {
+                    buildStageRecord.setProcessContextVariant(kafkaMessageDTO.getMdc().getProcessContextVariant());
+                }
                 return Optional.of(buildStageRecord);
             } else {
                 return Optional.empty();

--- a/src/main/java/org/jboss/pnc/kafkastore/model/BuildStageRecord.java
+++ b/src/main/java/org/jboss/pnc/kafkastore/model/BuildStageRecord.java
@@ -43,6 +43,8 @@ public class BuildStageRecord extends PanacheEntity {
     long duration;
     String buildId;
 
+    String processContextVariant;
+
     Instant timestamp;
 
     public static List<BuildStageRecord> getForBuildId(String buildId) {

--- a/src/test/java/org/jboss/pnc/kafkastore/model/BuildStageRecordTest.java
+++ b/src/test/java/org/jboss/pnc/kafkastore/model/BuildStageRecordTest.java
@@ -33,7 +33,7 @@ class BuildStageRecordTest {
 
         String buildId = "5";
         for (int i = 0; i < 15; i++) {
-            createBuildStageRecordWithBuildId(buildId, "test", 123);
+            createBuildStageRecordWithBuildId(buildId, "test", 123, "processVariant");
         }
         assertThat(BuildStageRecord.getForBuildId("5")).hasSize(15);
     }
@@ -42,11 +42,16 @@ class BuildStageRecordTest {
     // Helper methods
     // *****************************************************************************************************************
     @Transactional
-    void createBuildStageRecordWithBuildId(String buildId, String buildStage, int duration) {
+    void createBuildStageRecordWithBuildId(
+            String buildId,
+            String buildStage,
+            int duration,
+            String processContextVariant) {
         BuildStageRecord a = new BuildStageRecord();
         a.buildId = buildId;
         a.buildStage = buildStage;
         a.duration = duration;
+        a.processContextVariant = processContextVariant;
         a.persist();
     }
 


### PR DESCRIPTION
log-event-duration will now send "END" messages with the additional
'mdc.processContextVariant' that indicates a sub-category of a stage
(aka a retry happened).

kafka-store now adds all the durations for a build id with the same
stage, but with different `processContextVariant`. It will show the
total time of the stage, including with retries.

A future commit will be created to expose the "raw" data with the retry
information as a REST endpoint.