### PR TITLE
[NCL-7142] Allow to specify sasl authenticaton

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,10 +29,11 @@
 # See: https://stackoverflow.com/questions/55796370/quarkus-how-to-set-environment-variables-in-application-properties/55806466#55806466
 %prod.mp.messaging.incoming.duration.topic=${KAFKA_TOPIC:}
 %prod.mp.messaging.incoming.duration.bootstrap.servers=${KAFKA_SERVER:}
-
-%prod.mp.messaging.incoming.duration.security.protocol=SSL
+%prod.mp.messaging.incoming.duration.security.protocol=${SECURITY_PROTOCOL:SSL}
 %prod.mp.messaging.incoming.duration.ssl.truststore.location=${TRUSTSTORE_LOCATION:}
 %prod.mp.messaging.incoming.duration.ssl.truststore.password=${TRUSTSTORE_PASSWORD:}
+%prod.mp.messaging.incoming.duration.sasl.mechanism=${SASL_MECHANISM:}
+%prod.mp.messaging.incoming.duration.sasl.jaas.config=${JAAS_CONFIG:}
 %prod.mp.messaging.incoming.duration.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 # Consume only 50 records at a time to be more responsive (default is 500)
 %prod.mp.messaging.incoming.duration.max.poll.records=50


### PR DESCRIPTION
Allow to configure the application for sasl authentication by:

- setting the SECURITY_PROTOCOL env var to 'SASL_PLAIN'
- setting the SASL_MECHANISM env var to 'PLAIN'
- setting the JAAS_CONFIG env var to the jaas string containing the
  username and password