### PR TITLE
Downgrade Quarkus to 2.10.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>2.13.0.Final</quarkus.version>
+        <quarkus.version>2.10.4.Final</quarkus.version>
         <compiler-plugin.version>3.10.1</compiler-plugin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is the last version that uploads uber jars to Maven Central. The issue with the latest Quarkus version will be fixed in a future release.