### PR TITLE
Refine ghaction to update jib base image

### DIFF
--- a/.github/workflows/update-base-image.yml
+++ b/.github/workflows/update-base-image.yml
@@ -23,11 +23,18 @@ jobs:
         id: check-image
         run: |
           # Extract current values from pom.xml
-          CURRENT_VERSION=$(grep -oP '<jib.base.image.version>\K[^<]+' pom.xml)
-          CURRENT_DIGEST=$(grep -oP '<jib.base.image.digest>\K[^<]+' pom.xml)
+          # <image>:<version>@<digest>
+          IMAGE_POM=$(grep -oP '<quarkus.jib.base-jvm-image>\K[^<]+' pom.xml)
 
-          IMAGE="registry.access.redhat.com/ubi10/openjdk-21-runtime"
+          IMAGE="${IMAGE_POM%%:*}"
 
+          tag_and_digest="${IMAGE_POM#*:}"
+          CURRENT_VERSION="${tag_and_digest%@*}"
+
+          CURRENT_DIGEST="${IMAGE_POM##*@}"
+
+
+          echo "Current image: $IMAGE"
           echo "Current version: $CURRENT_VERSION"
           echo "Current digest: $CURRENT_DIGEST"
 
@@ -55,6 +62,7 @@ jobs:
             {
               echo "update_needed=true"
               echo "new_version=$LATEST_VERSION"
+              echo "image=$IMAGE"
               echo "new_digest=$LATEST_DIGEST"
               echo "current_version=$CURRENT_VERSION"
               echo "current_digest=$CURRENT_DIGEST"
@@ -72,10 +80,7 @@ jobs:
           NEW_DIGEST: ${{ steps.check-image.outputs.new_digest }}
         run: |
           # Update the version in pom.xml
-          sed -i "s|<jib.base.image.version>.*</jib.base.image.version>|<jib.base.image.version>${NEW_VERSION}</jib.base.image.version>|" pom.xml
-
-          # Update the digest in pom.xml
-          sed -i "s|<jib.base.image.digest>.*</jib.base.image.digest>|<jib.base.image.digest>${NEW_DIGEST}</jib.base.image.digest>|" pom.xml
+          sed -i "s|<quarkus.jib.base-jvm-image>.*</quarkus.jib.base-jvm-image>|<quarkus.jib.base-jvm-image>${IMAGE}:${NEW_VERSION}@${NEW_DIGEST}</quarkus.jib.base-jvm-image>|" pom.xml
 
           echo "Updated pom.xml with new version and digest"
 
@@ -87,19 +92,19 @@ jobs:
           commit-message: |
             Update Jib base image to ${{ steps.check-image.outputs.new_version }}
 
-            Update openjdk-21-runtime from ${{ steps.check-image.outputs.current_version }} to ${{ steps.check-image.outputs.new_version }}
+            Update ${{ steps.check-image.outputs.image }} from ${{ steps.check-image.outputs.current_version }} to ${{ steps.check-image.outputs.new_version }}
 
             Previous digest: ${{ steps.check-image.outputs.current_digest }}
             New digest: ${{ steps.check-image.outputs.new_digest }}
           branch: update-jib-base-image
           delete-branch: true
-          title: 'chore: Update Jib base image to openjdk-21-runtime:${{ steps.check-image.outputs.new_version }}'
+          title: 'chore: Update Jib base image to ${{ steps.check-image.outputs.image }}:${{ steps.check-image.outputs.new_version }}'
           body: |
             ## Base Image Update
 
             This PR updates the Jib base image to the latest available version.
 
-            **Image:** `registry.access.redhat.com/ubi10/openjdk-21-runtime`
+            **Image:** `${{ steps.check-image.outputs.image }}`
 
             **Changes:**
             - Previous version: `${{ steps.check-image.outputs.current_version }}`
@@ -110,10 +115,6 @@ jobs:
             ${{ steps.check-image.outputs.version_changed == 'true' && '**Version Update**: This update includes a new version of the base image, which may include significant updates, security patches, and bug fixes.' || '**Digest Update**: This update only changes the digest for the same version, typically indicating security patches or minor OS updates.' }}
 
             This is an automated PR created by the Update Jib Base Image workflow.
-
-            ### Verification
-
-            Please review the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/ubi10/openjdk-21-runtime) for release notes and changelogs.
           labels: |
             dependencies
             automated

--- a/pom.xml
+++ b/pom.xml
@@ -70,15 +70,11 @@
         <version.source.plugin>3.4.0</version.source.plugin>
         <pushChanges>true</pushChanges>
         <!--
-           - <quarkus.package.type>uber-jar</quarkus.package.type>
-           -->
-        <!--
-           - we specify both version and digest so that dependabot updates
+           - we specify both version and digest so that gh-action updates
            - both. The version is great for humans, the digest great for
            - pinning the version properly
           -->
-        <jib.base.image.version>1.24-7</jib.base.image.version>
-        <jib.base.image.digest>sha256:5ee73448f86838eecff13f80512b49ff6ea0fa21aaf5d1fa8afe3402fc965e9e</jib.base.image.digest>
+        <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-3@sha256:70615949ee08ef225709e64c55f7f9a658940dd963509ee47eab4766a11c2a49</quarkus.jib.base-jvm-image>
         <tagSuffix />
     </properties>
 
@@ -197,11 +193,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <finalName>kafka-store</finalName>
-                    <systemProperties>
-                        <quarkus.jib.base-jvm-image>
-                            registry.access.redhat.com/ubi10/openjdk-21-runtime:${jib.base.image.version}@${jib.base.image.digest}
-                        </quarkus.jib.base-jvm-image>
-                    </systemProperties>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
It should now handle any base-jvm-image instead of just jdk21.